### PR TITLE
Add lud16 field to BaseUser

### DIFF
--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -7,12 +7,16 @@ class BaseUser extends BaseEvent<BaseUser> {
     Set<String>? tags,
     String? name,
     String? avatarUrl,
+    String? lud16,
   }) : super(
           createdAt: createdAt,
           pubkeys: pubkeys,
           tags: tags,
-          content: jsonEncode(
-              <String, dynamic>{'name': name, 'picture': avatarUrl}.nonNulls),
+          content: jsonEncode(<String, dynamic>{
+            'name': name,
+            'picture': avatarUrl,
+            'lud16': lud16
+          }.nonNulls),
         );
 
   BaseUser.fromJson(Map<String, dynamic> map) : super.fromJson(map);

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -57,6 +57,7 @@ class BaseUser extends BaseEvent<BaseUser> {
 
   String get npub => bech32Encode('npub', pubkey);
   String? get avatarUrl => _content['picture'];
+  String? get lud16 => _content['lud16'];
 }
 
 extension Bech32StringX on String {


### PR DESCRIPTION
Even if not in any NIP spec, such field has been widely used by most popular clients, and it is mentioned in zap nip57 spec, so I think we should have it parsed and available for starting zap support in zapstore. 
Even if we later refactor to use ndk, it isn't much additional work to adapt to it later on.